### PR TITLE
adding comparison tolerance feature

### DIFF
--- a/packages/monte_carlo/collision/core/src/MonteCarlo_MaterialHelpers_def.hpp
+++ b/packages/monte_carlo/collision/core/src/MonteCarlo_MaterialHelpers_def.hpp
@@ -82,7 +82,7 @@ bool areFractionValuesNormalized( Iterator start, Iterator end )
 
   sum = std::fabs( sum );
 
-  if( std::fabs( sum - 1.0 ) < Utility::QuantityTraits<double>::epsilon() )
+  if( std::fabs( sum - 1.0 ) < Utility::QuantityTraits<double>::comparisonTolerance() )
     return true;
   else
     return false;

--- a/packages/utility/core/src/Utility_QuantityTraits.hpp
+++ b/packages/utility/core/src/Utility_QuantityTraits.hpp
@@ -708,6 +708,10 @@ protected:
   static inline T rawEpsilon() noexcept
   { return std::numeric_limits<T>::epsilon(); }
 
+    //! Get comparison tolerance
+  static inline T rawComparisonTolerance() noexcept
+  { return (T)1.e-15; }
+
   //! Get the maximum rounding error
   static inline T rawRoundError() noexcept
   { return std::numeric_limits<T>::round_error(); }
@@ -769,6 +773,10 @@ protected:
   //! Get the machine epsilon
   static inline std::complex<T> rawEpsilon() noexcept
   { return std::complex<T>(ParallelBaseType::rawEpsilon(), ParallelBaseType::rawZero()); }
+
+    //! Get comparison tolerance
+  static inline std::complex<T> rawComparisonTolerance() noexcept
+  { return std::complex<T>(ParallelBaseType::rawComparisonTolerance(), ParallelBaseType::rawZero()); }
 
   //! Get the maximum rounding error
   static inline std::complex<T> rawRoundError() noexcept
@@ -1155,6 +1163,10 @@ public:
   static inline typename BaseType::QuantityType epsilon() noexcept
   { return BaseType::rawEpsilon(); }
 
+  //! Get comparison tolerence
+  static inline typename BaseType::QuantityType comparisonTolerance() noexcept
+  { return BaseType::rawComparisonTolerance(); }
+
   //! Get the maximum rounding error
   static inline typename BaseType::QuantityType roundError() noexcept
   { return BaseType::rawRoundError(); }
@@ -1204,6 +1216,10 @@ public:
   static inline typename BaseType::QuantityType epsilon() noexcept
   { return BaseType::rawEpsilon(); }
 
+  //! Get comparison tolerance
+  static inline typename BaseType::QuantityType comparisonTolerance() noexcept
+  { return BaseType::rawComparisonTolerance(); }
+
   //! Get the maximum rounding error
   static inline typename BaseType::QuantityType roundError() noexcept
   { return BaseType::rawRoundError(); }
@@ -1250,6 +1266,10 @@ public:
   static inline typename BaseType::QuantityType epsilon() noexcept
   { return BaseType::QuantityType::from_value( BaseType::rawEpsilon() ); }
 
+ //! Get comparison tolerance
+  static inline typename BaseType::QuantityType comparisonTolerance() noexcept
+  { return BaseType::QuantityType::from_value( BaseType::rawComparisonTolerance() ); }
+
   //! Get the maximum rounding error
   static inline typename BaseType::QuantityType roundError() noexcept
   { return BaseType::QuantityType::from_value( BaseType::rawRoundError() ); }
@@ -1292,6 +1312,10 @@ public:
   //! Get the machine epsilon
   static inline typename BaseType::QuantityType epsilon() noexcept
   { return BaseType::QuantityType::from_value( BaseType::rawEpsilon() ); }
+
+  //! Get comparison tolerance
+  static inline typename BaseType::QuantityType comparisonTolerance() noexcept
+  { return BaseType::QuantityType::from_value( BaseType::rawComparisonTolerance() ); }
 
   //! Get the maximum rounding error
   static inline typename BaseType::QuantityType roundError() noexcept

--- a/packages/utility/core/src/Utility_QuantityTraitsDecl.hpp
+++ b/packages/utility/core/src/Utility_QuantityTraitsDecl.hpp
@@ -215,6 +215,10 @@ struct QuantityTraits
   static inline QuantityType epsilon() noexcept
   { return UndefinedQuantityTraits<T>::notDefined(); }
 
+    //! Get comparison tolerance (only defined for floating-point types)
+  static inline QuantityType comparisonTolerance() noexcept
+  { return UndefinedQuantityTraits<T>::notDefined(); }
+
   //! Get the maximum rounding error (only defined for floating-point types)
   static inline QuantityType roundError() noexcept
   { return UndefinedQuantityTraits<T>::notDefined(); }

--- a/packages/utility/core/test/tstQuantityTraits.cpp
+++ b/packages/utility/core/test/tstQuantityTraits.cpp
@@ -1583,6 +1583,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( epsilon,
 }
 
 //---------------------------------------------------------------------------//
+// Check that the comparison tolerance (10^-15) can be returned
+BOOST_AUTO_TEST_CASE_TEMPLATE( comparison_tolerance_basic, T, TestFloatingPointTypes )
+{
+  BOOST_CHECK_EQUAL( Utility::QuantityTraits<T>::comparisonTolerance(),
+                     1.e-15 );
+  BOOST_CHECK_EQUAL( Utility::QuantityTraits<std::complex<T> >::comparisonTolerance(),
+                     std::complex<T>( 1.e-15 , 0 ) );
+}
+
+//---------------------------------------------------------------------------//
+// Check that the comparison tolerance (10^-15) can be returned
+BOOST_AUTO_TEST_CASE_TEMPLATE( comparison_tolerance,
+                               QuantityType,
+                               TestBasicFloatingPointQuantityTypes )
+{
+  typedef typename Utility::QuantityTraits<QuantityType>::RawType RawType;
+  typedef typename Utility::QuantityTraits<QuantityType>::UnitType UnitType;
+
+  BOOST_CHECK_EQUAL( Utility::QuantityTraits<QuantityType>::comparisonTolerance(),
+                     QuantityType::from_value( 1.e-15 ) );
+
+  typedef std::complex<RawType> ComplexRawType;
+  typedef typename Utility::UnitTraits<UnitType>::template GetQuantityType<std::complex<RawType> >::type ComplexQuantityType;
+
+  BOOST_CHECK_EQUAL( Utility::QuantityTraits<ComplexQuantityType>::comparisonTolerance(),
+                     ComplexQuantityType::from_value( ComplexRawType( 1.e-15 , 0 ) ) );
+}
+
+//---------------------------------------------------------------------------//
 // Check that the max rounding error can be returned
 BOOST_AUTO_TEST_CASE_TEMPLATE( roundError_basic, T, TestFloatingPointTypes )
 {


### PR DESCRIPTION
This PR is intended to add the comparisonTolerance function to the Utility_QuantityTraits class so that comparisons with a tolerance of 1e-15 can be made. Due to floating point error, some material comparison had a slightly larger error than the previously allowed machine precision. This PR is also made to isolate the smaller problem away from the larger issues in the neutron data reader bug fix PR: #196 