### PR TITLE
Replace literal in comparison tolerance

### DIFF
--- a/packages/utility/core/src/Utility_QuantityTraits.hpp
+++ b/packages/utility/core/src/Utility_QuantityTraits.hpp
@@ -710,7 +710,7 @@ protected:
 
     //! Get comparison tolerance
   static inline T rawComparisonTolerance() noexcept
-  { return (T)1.e-15; }
+  { return 10*rawEpsilon(); }
 
   //! Get the maximum rounding error
   static inline T rawRoundError() noexcept

--- a/packages/utility/core/test/tstQuantityTraits.cpp
+++ b/packages/utility/core/test/tstQuantityTraits.cpp
@@ -1587,9 +1587,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( epsilon,
 BOOST_AUTO_TEST_CASE_TEMPLATE( comparison_tolerance_basic, T, TestFloatingPointTypes )
 {
   BOOST_CHECK_EQUAL( Utility::QuantityTraits<T>::comparisonTolerance(),
-                     1.e-15 );
+                     10*std::numeric_limits<T>::epsilon() );
   BOOST_CHECK_EQUAL( Utility::QuantityTraits<std::complex<T> >::comparisonTolerance(),
-                     std::complex<T>( 1.e-15 , 0 ) );
+                     std::complex<T>( 10*std::numeric_limits<T>::epsilon(), 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -1602,13 +1602,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( comparison_tolerance,
   typedef typename Utility::QuantityTraits<QuantityType>::UnitType UnitType;
 
   BOOST_CHECK_EQUAL( Utility::QuantityTraits<QuantityType>::comparisonTolerance(),
-                     QuantityType::from_value( 1.e-15 ) );
+                     QuantityType::from_value( 10*std::numeric_limits<RawType>::epsilon() ) );
 
   typedef std::complex<RawType> ComplexRawType;
   typedef typename Utility::UnitTraits<UnitType>::template GetQuantityType<std::complex<RawType> >::type ComplexQuantityType;
 
   BOOST_CHECK_EQUAL( Utility::QuantityTraits<ComplexQuantityType>::comparisonTolerance(),
-                     ComplexQuantityType::from_value( ComplexRawType( 1.e-15 , 0 ) ) );
+                     ComplexQuantityType::from_value( ComplexRawType( 10*std::numeric_limits<RawType>::epsilon() , 0 ) ) );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
In the past pull request (PR #202) that attempted to add a comparison tolerance, the value was set with a literal `1.0e-15`. The comparison tolerance was created for systems that need a slightly looser than the  maximum machine precision. This pull request changes this to be `10*rawEpsilon()`, so that when it is compared, it does not use a float literal and instead depends on the precision set by the machine. This pull request should be merged before PR #221 so that that PR can be rebased to start after these changes.