### PR TITLE
Fixed more history bugs related to 32 bit variables

### DIFF
--- a/packages/monte_carlo/event/core/src/MonteCarlo_ParticleHistorySimulationCompletionCriterion.cpp
+++ b/packages/monte_carlo/event/core/src/MonteCarlo_ParticleHistorySimulationCompletionCriterion.cpp
@@ -46,11 +46,9 @@ public:
     // Make sure only the root thread calls this
     testPrecondition( Utility::OpenMPProperties::getThreadId() == 0 );
     
-    uint64_t init = 0;
-
     return std::accumulate( d_num_completed_histories.begin(),
                             d_num_completed_histories.end(),
-                            init );
+                            0ull );
   }
 
   //! Check if the simulation is complete

--- a/packages/monte_carlo/event/dispatcher/src/MonteCarlo_EventHandler.cpp
+++ b/packages/monte_carlo/event/dispatcher/src/MonteCarlo_EventHandler.cpp
@@ -720,7 +720,7 @@ uint64_t EventHandler::getNumberOfCommittedHistories() const
 {
   return std::accumulate( d_number_of_committed_histories.begin(),
                           d_number_of_committed_histories.end(),
-                          0 );
+                          0ull );
 }
 
 // Get the number of particle histories committed since the last snapshot
@@ -728,7 +728,7 @@ uint64_t EventHandler::getNumberOfCommittedHistoriesSinceLastSnapshot() const
 {
   return std::accumulate( d_number_of_committed_histories_from_last_snapshot.begin(),
                           d_number_of_committed_histories_from_last_snapshot.end(),
-                          0 );
+                          0ull );
 }
 
 // Reset the number of committed histories since the last snapshot

--- a/packages/monte_carlo/event/dispatcher/test/tstEventHandler.cpp
+++ b/packages/monte_carlo/event/dispatcher/test/tstEventHandler.cpp
@@ -708,9 +708,15 @@ FRENSIE_UNIT_TEST( EventHandler, getNumberOfCommittedHistories )
 
   FRENSIE_CHECK_EQUAL( event_handler.getNumberOfCommittedHistories(), 0 );
 
-  event_handler.commitObserverHistoryContributions();
-
-  FRENSIE_CHECK_EQUAL( event_handler.getNumberOfCommittedHistories(), 1 );
+  // Test for ability to use 64 bit variables
+  uint64_t completed_histories = 5000000000;
+  
+  for(uint64_t history = 0; history < completed_histories; history++)
+  {
+    event_handler.commitObserverHistoryContributions();
+  }
+  
+  FRENSIE_CHECK_EQUAL( event_handler.getNumberOfCommittedHistories(), completed_histories );
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/monte_carlo/event/dispatcher/test/tstEventHandler.cpp
+++ b/packages/monte_carlo/event/dispatcher/test/tstEventHandler.cpp
@@ -9,6 +9,7 @@
 // Std Lib Includes
 #include <iostream>
 #include <memory>
+#include <cmath>
 
 // FRENSIE Includes
 #include "MonteCarlo_EventHandler.hpp"
@@ -709,7 +710,7 @@ FRENSIE_UNIT_TEST( EventHandler, getNumberOfCommittedHistories )
   FRENSIE_CHECK_EQUAL( event_handler.getNumberOfCommittedHistories(), 0 );
 
   // Test for ability to use 64 bit variables
-  uint64_t completed_histories = 5000000000;
+  uint64_t completed_histories = (uint64_t)std::pow(2.0, 33.0);
   
   for(uint64_t history = 0; history < completed_histories; history++)
   {


### PR DESCRIPTION
Fixed another history bug that had to do with d_number_of_committed_histories using 32 bit variables which is used in calculating various statistical parameters and made a small change to an earlier PR that makes it consistent in style with this change.