### PR TITLE
Fisblockfix

### DIFF
--- a/packages/PyFrensie/test/tstData.ACE.XSSNeutronDataExtractor.py.in
+++ b/packages/PyFrensie/test/tstData.ACE.XSSNeutronDataExtractor.py.in
@@ -369,9 +369,9 @@ class XSSNeutronDataExtractorU238TestCase(unittest.TestCase):
     def testExtractSIGBlock(self):
         "*Test Data.ACE.XSSNeutronDataExtractor extractSIGBlock method"
         sig_block = self.xss_extractor.extractSIGBlock()
-        self.assertEqual(len(sig_block), 191)
+        self.assertEqual(len(sig_block), 481823)
         self.assertEqual(sig_block[0], 157648)
-        self.assertEqual(sig_block[len(sig_block)-1], 1.716853e-01)
+        self.assertEqual(sig_block[len(sig_block)-1], 3.216104e-01)
 
     def testExtractLANDBlock(self):
         "*Test Data.ACE.XSSNeutronDataExtractor extractLANDBlock method"

--- a/packages/data/ace/src/Data_ACEBlocks.hpp
+++ b/packages/data/ace/src/Data_ACEBlocks.hpp
@@ -44,10 +44,10 @@ enum blockId  {  esz, // 0, location of energy table
                 ldlwp, // 17, location of table of photon production energy distribution locators
                 dlwp, // 18, location of photon production energy distributions
                 yp, // 19, location of table of yield multipliers
-                fis, // 20, location of totalf ission cross section
-                end, // 21, locaiton of end of last non particle production block ( this is different from nxs[xss_length] sometimes )
+                fis, // 20, location of total fission cross section
+                end, // 21, location of the last value in the table of last non particle production block ( this is different from nxs[xss_length] sometimes )
                 lunr, // 22, location of probability tables
-                dnu, // 23, locaiton of delayed nubar data
+                dnu, // 23, location of delayed nubar data
                 bdd, //24, location of basic delayed data (decay rates and probabilities)
                 dnedl, // 25,  location of table of energy distirbution locators 
                 dned, // 26, location or energy distributions

--- a/packages/data/ace/test/tstXSSNeutronDataExtractorU238.cpp
+++ b/packages/data/ace/test/tstXSSNeutronDataExtractorU238.cpp
@@ -255,9 +255,9 @@ FRENSIE_UNIT_TEST( XSSNeutronDataExtractor, extractSIGBlock_u238 )
   Utility::ArrayView<const double> sig_block =
     xss_data_extractor_u238->extractSIGBlock();
 
-  FRENSIE_CHECK_EQUAL( sig_block.size(), 191 );
+  FRENSIE_CHECK_EQUAL( sig_block.size(), 481823 );
   FRENSIE_CHECK_EQUAL( sig_block.front(), 157648 );
-  FRENSIE_CHECK_EQUAL( sig_block.back(), 1.716853e-01); // Value in line 2878303 last column (191 entries after start)
+  FRENSIE_CHECK_EQUAL( sig_block.back(), 3.21604e-01); 
 }
 
 //---------------------------------------------------------------------------//

--- a/packages/data/ace/test/tstXSSNeutronDataExtractorU238.cpp
+++ b/packages/data/ace/test/tstXSSNeutronDataExtractorU238.cpp
@@ -257,7 +257,7 @@ FRENSIE_UNIT_TEST( XSSNeutronDataExtractor, extractSIGBlock_u238 )
 
   FRENSIE_CHECK_EQUAL( sig_block.size(), 481823 );
   FRENSIE_CHECK_EQUAL( sig_block.front(), 157648 );
-  FRENSIE_CHECK_EQUAL( sig_block.back(), 3.21604e-01); 
+  FRENSIE_CHECK_EQUAL( sig_block.back(), 3.216104000000000185e-01); 
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR fixes the mistaken assumption that the `fis` block is not a subset of the `sig` block. The `sig` block contains all neutron-in reactions that are not elastic scattering. Fission is a neutron-in reaction that is not elastic scattering, but because of its importance in Monte Carlo simulations, it has a special designation in the MCNP manual. This caused the FRENSIE team to treat it as a separate block when that should not have been done. Because of the algorithm introduced in PR #221, treating the `fis` block as its own block interrupted data in the `sig` block that came before and after the`fis` block. Thus the size of the `sig` block was incorrect and too small.  

This mistaken assumption caused an exception to be thrown by the `ArrayView` class. This issue was uncovered when an isotope with a `fis` block was included in the simulation, namely U235. FRENSIE expected the `sig` block to have a larger size, so a precondition test in the `ArrayView` class threw an exception that the start of the block was invalid.  

The fix treats the `fis` block as a special case and only adds it into the map at the end of the computation, if the block is present. With this change, the size of the `sig` block is not interrupted by the `fis` block and the `ArrayView` exception is not raised.  Some of the values in the FRENSIE tests involving U238 had to be changed (and actually reverted to the values they had before #PR221 changed them). These now reflect the correct size of the sig block. With these changes, all tests are passing (outside of the test mentioned by Issue #219 ). Additionally the simulation that was originally throwing an exception now runs.